### PR TITLE
fixed gambreaker with processInput()

### DIFF
--- a/de/hsa/games/fatsquirrel/console/GameImpl.java
+++ b/de/hsa/games/fatsquirrel/console/GameImpl.java
@@ -26,16 +26,16 @@ public class GameImpl extends Game {
 			
 			
 				Command cmd;
+				while(true) {
 				try {
 					cmd = ui.getCommand();
 					cmd.commandTypeInfo.execute(masterSquirrel, cmd.params);
+					break;
 				} catch (Exception ex) {
 					ex.printStackTrace();
 					continue;
-				}finally{
-				processInput();				//rekursiver aufruf bei exception damit programm nicht stoppt
 				}
-				
+				}
 			
 			
 			


### PR DESCRIPTION
Eingaben wurden nicht mehr erkannt wegen dem rekursiven aufruf von processInput()
rekursion entfernt und durch eine schleife ersetzt